### PR TITLE
Fix: Problems when unregistering eventfd with io_uring

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ From the depths of the sea, where darkness meets vastness, emerges Leviathan: an
 
 - Python 3.13+
 - Zig 0.14.x (for development or contributions)
+- Linux >= 5.1
 
 ## 🔧 Installation
 

--- a/build.zig
+++ b/build.zig
@@ -37,6 +37,16 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    if (target.result.os.tag != .linux) {
+        @panic("Only Linux is supported");
+    }else if (target.result.os.isAtLeast(.linux, .{ .major = 5, .minor = 1, .patch = 0 })) |_is_at_least| {
+        if (!_is_at_least) {
+            @panic("Only Linux >= 5.1.0 is supported");
+        }
+    }else{
+        @panic("Not able to detect Linux version");
+    }
+
     const python_include_dir = b.option([]const u8, "python-include-dir", "Path to python include directory")
         orelse "/usr/include/python3.13";
 

--- a/src/loop/scheduling/io/main.zig
+++ b/src/loop/scheduling/io/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 const linked_list =  @import("../../../utils/linked_list.zig");
 pub const BlockingTasksSetLinkedList = linked_list.init(*BlockingTasksSet);
@@ -68,10 +69,8 @@ pub const BlockingTasksSet = struct {
 
         const node = self.node;
 
-        self.ring.unregister_eventfd() catch unreachable;
-        std.posix.close(self.eventfd);
-
         self.ring.deinit();
+        std.posix.close(self.eventfd);
         self.allocator.destroy(self);
         return node;
     }


### PR DESCRIPTION
Look like in old versions of linux (<6.3), unregister_eventfd functionality is not available and cause freeze